### PR TITLE
Made work for generic torchvision datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ You can use our training configurations provided in `configs/classification`:
 ./dist_classification.sh 8 -c configs/classification/convmlp_l_imagenet.yml /path/to/ImageNet
 ```
 
+<details>
+<summary>Running other torchvision datasets.</summary>
+WARNING: This may not always work as intended. Be sure to check that you have
+properly created the config files for this to work.
+
+We support running arbitrary [torchvision
+datasets](https://pytorch.org/vision/stable/datasets.html). To do this you need
+to edit the config files to include the new dataset and prepend with "tv-". For
+example, if you want to run ConvMLP with CIFAR10 you should have `dataset:
+tv-CIFAR10` in the yaml file. Capitalization (of the dataset) matters. You are
+also able to download the datasets by adding `download: True`, but it is
+suggested not to do this. We suggest this because you will need to calculate the
+mean and standard deviation for each dataset to get the best results.
+</details>
+
 
 ## Object Detection
 [mmdetection](https://github.com/open-mmlab/mmdetection) is recommended for object detection training

--- a/classification.py
+++ b/classification.py
@@ -23,6 +23,7 @@ import logging
 from collections import OrderedDict
 from contextlib import suppress
 from datetime import datetime
+from importlib import import_module
 
 import torch
 import torch.nn as nn
@@ -79,6 +80,8 @@ parser.add_argument('data_dir', metavar='DIR',
                     help='path to dataset')
 parser.add_argument('--dataset', '-d', metavar='NAME', default='',
                     help='dataset type (default: ImageFolder/ImageTar if empty)')
+parser.add_argument('--download', action='store_true',
+                    help="Download the dataset. Used for torchvision datasets.")
 parser.add_argument('--train-split', metavar='NAME', default='train',
                     help='dataset train split (default: train)')
 parser.add_argument('--val-split', metavar='NAME', default='validation',
@@ -473,12 +476,18 @@ def main():
         _logger.info('Scheduled epochs: {}'.format(num_epochs))
 
     # create the train and eval datasets
-    dataset_train = create_dataset(
-        args.dataset,
-        root=args.data_dir, split=args.train_split, is_training=True,
-        batch_size=args.batch_size, repeats=args.epoch_repeats)
-    dataset_eval = create_dataset(
-        args.dataset, root=args.data_dir, split=args.val_split, is_training=False, batch_size=args.batch_size)
+    if args.dataset[:2].lower() == "tv":
+        ''' Imports an arbitrary torchvision dataset if it begins with 'tv-' '''
+        tvdataset = getattr(import_module("torchvision.datasets"), args.dataset[3:])
+        dataset_train = tvdataset(root=args.data_dir, train=True, download=args.download)
+        dataset_test  = tvdataset(root=args.data_dir, train=False, download=args.download)
+    else:
+        dataset_train = create_dataset(
+            args.dataset,
+            root=args.data_dir, split=args.train_split, is_training=True,
+            batch_size=args.batch_size, repeats=args.epoch_repeats)
+        dataset_eval = create_dataset(
+            args.dataset, root=args.data_dir, split=args.val_split, is_training=False, batch_size=args.batch_size)
 
     # setup mixup / cutmix
     collate_fn = None

--- a/classification.py
+++ b/classification.py
@@ -489,11 +489,11 @@ def main():
             dataset_eval  = tvdataset(root=args.data_dir, train=False)
         except TypeError: # Errors when train keyword doesn't exist
             try:
-                dataset_train = tvdataset(root=args.data_dir, split='train', download=args.download)
-                dataset_eval  = tvdataset(root=args.data_dir, split='test', download=args.download)
+                dataset_train = tvdataset(root=args.data_dir, split=args.train_split, download=args.download)
+                dataset_eval  = tvdataset(root=args.data_dir, split=args.val_split, download=args.download)
             except RuntimeError:
-                dataset_train = tvdataset(root=args.data_dir, split='train')
-                dataset_eval  = tvdataset(root=args.data_dir, split='test')
+                dataset_train = tvdataset(root=args.data_dir, split=args.train_split)
+                dataset_eval  = tvdataset(root=args.data_dir, split=args.val_split)
         except Exception as e:
             print(f"Couldn't load the dataset. Got error: {e}")
 

--- a/configs/classification/finetuned/convmlp_l_cifar10.yml
+++ b/configs/classification/finetuned/convmlp_l_cifar10.yml
@@ -1,0 +1,48 @@
+dataset: cifar10
+num_classes: 10
+img_size: 224
+mean:
+    - 0.4914
+    - 0.4822
+    - 0.4465
+std:
+    - 0.2470
+    - 0.2435
+    - 0.2616
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 64
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_l_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_l_cifar100.yml
+++ b/configs/classification/finetuned/convmlp_l_cifar100.yml
@@ -1,0 +1,48 @@
+dataset: cifar100
+num_classes: 100
+img_size: 224
+mean:
+    - 0.5071
+    - 0.4867
+    - 0.4408
+std:
+    - 0.2675
+    - 0.2565
+    - 0.2761
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 64
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_l_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_l_flowers102.yml
+++ b/configs/classification/finetuned/convmlp_l_flowers102.yml
@@ -1,0 +1,50 @@
+dataset: flowers102
+num_classes: 102
+img_size: 224
+train_split: train
+val_split: valid
+mean:
+    - 0.4353
+    - 0.3773
+    - 0.2872
+std:
+    - 0.2966
+    - 0.2455
+    - 0.2698
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 64
+lr: 3e-4
+min_lr: 1e-8
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_l_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_m_cifar10.yml
+++ b/configs/classification/finetuned/convmlp_m_cifar10.yml
@@ -1,0 +1,48 @@
+dataset: cifar10
+num_classes: 10
+img_size: 224
+mean:
+    - 0.4914
+    - 0.4822
+    - 0.4465
+std:
+    - 0.2470
+    - 0.2435
+    - 0.2616
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 128
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_m_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_m_cifar100.yml
+++ b/configs/classification/finetuned/convmlp_m_cifar100.yml
@@ -1,0 +1,48 @@
+dataset: cifar100
+num_classes: 100
+img_size: 224
+mean:
+    - 0.5071
+    - 0.4867
+    - 0.4408
+std:
+    - 0.2675
+    - 0.2565
+    - 0.2761
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 128
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_m_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_m_flowers102.yml
+++ b/configs/classification/finetuned/convmlp_m_flowers102.yml
@@ -1,0 +1,50 @@
+dataset: flowers102
+num_classes: 102
+img_size: 224
+train_split: train
+val_split: valid
+mean:
+    - 0.4353
+    - 0.3773
+    - 0.2872
+std:
+    - 0.2966
+    - 0.2455
+    - 0.2698
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 96
+lr: 3e-4
+min_lr: 1e-8
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_l_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_s_cifar10.yml
+++ b/configs/classification/finetuned/convmlp_s_cifar10.yml
@@ -1,0 +1,48 @@
+dataset: cifar10
+num_classes: 10
+img_size: 224
+mean:
+    - 0.4914
+    - 0.4822
+    - 0.4465
+std:
+    - 0.2470
+    - 0.2435
+    - 0.2616
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 128
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_s_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_s_cifar100.yml
+++ b/configs/classification/finetuned/convmlp_s_cifar100.yml
@@ -1,0 +1,48 @@
+dataset: cifar100
+num_classes: 100
+img_size: 224
+mean:
+    - 0.5071
+    - 0.4867
+    - 0.4408
+std:
+    - 0.2675
+    - 0.2565
+    - 0.2761
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 128
+lr: 3e-4
+min_lr: 1e-5
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_s_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/finetuned/convmlp_s_flowers102.yml
+++ b/configs/classification/finetuned/convmlp_s_flowers102.yml
@@ -1,0 +1,50 @@
+dataset: flowers102
+num_classes: 102
+img_size: 224
+train_split: train
+val_split: valid
+mean:
+    - 0.4353
+    - 0.3773
+    - 0.2872
+std:
+    - 0.2966
+    - 0.2455
+    - 0.2698
+amp: True
+epochs: 50
+cooldown_epochs: 10
+warmup_epochs: 10
+patience_epochs: 10
+batch_size: 96
+lr: 5e-4
+min_lr: 1e-8
+warmup_lr: 1e-6
+sched: cosine
+weight_decay: 0.05
+opt: adamw
+smoothing: 0.1
+model: convmlp_l_classification
+pretrained: True
+model_ema: False
+hflip: 0.5
+vflip: 0.0
+ratio:
+    - 0.75
+    - 1.3333333333333333
+crop_pct: 1.0
+scale:
+    - 0.8
+    - 1.0
+interpolation: bicubic
+train_interpolation: random
+recount: 1
+remode: pixel
+reprob: 0.25
+aa: rand-m9-mstd0.5-inc1
+mixup: 0.8
+mixup_mode: batch
+mixup_off_epoch: 0
+mixup_prob: 1.0
+mixup_switch_prob: 0.5
+cutmix: 1.0

--- a/configs/classification/template.yml
+++ b/configs/classification/template.yml
@@ -1,0 +1,83 @@
+# Template configuration file
+
+# Dataset
+# dataset: mydataset # Leave empty to default to ImageFolder
+# download: False
+# You can also use torchvision datasets, as long as they are valid
+# classification datasets. Prepend the name with `tv`.
+# i.e. tv-cifar10
+train_split: train # Train split; in case your dataset expects a special directory or split name
+val_split: valid # Validation split; i.e. `val` for ImageNet, `valid` for Flowers-102
+
+num_classes: 102
+img_size: 224
+
+# Dataset statistics
+# The mean and std are computed per channel over the training set
+# This means that it is specific to each dataset.
+mean:
+    - 0.4353
+    - 0.3773
+    - 0.2872
+std:
+    - 0.2966
+    - 0.2455
+    - 0.2698
+
+
+crop_pct: 1.0 # Validation set crop percentage; usually 0.875 for ImageNet
+# Why 0.875? Because images are usually resized to 256x256 and center cropped
+# at 87.5% which gives you 224x224.
+
+# Dataloader
+train_interpolation: bicubic
+interpolation: bicubic
+batch_size: 128
+workers: 8
+
+# Data augmentations
+scale: # Random Crop scale
+    - 0.8
+    - 1.0
+ratio: # Random Crop aspect ratio
+    - 0.75
+    - 1.33
+# Augmentation Policies
+# See `timm` docs for details on this particular argument
+# Default is RandAugment with magnitude 9, magnitude std of 0.5
+aa: rand-m9-mstd0.5-inc1
+
+reprob: 0.25  # Random erase probability
+remode: pixel # Random erase mode
+
+color_jitter: 0 # Color Jitter probability
+hflip: 0        # Horizontal Flip probability
+vflip: 0        # Vertical Flip probability
+
+# Mixup and CutMix
+mixup: 0.8             # Mixup alpha
+mixup_prob: 1.0        # Mixup probability
+cutmix: 1.0            # Cutmix probability
+mixup_off_epoch: 0     # Which epoch to turn off Mixup, 0 = never
+mixup_mode: batch      # Mixup mode
+mixup_switch_prob: 0.5 # Probability of switching Mixup with CutMix
+
+
+# Training settings
+amp: True # Enable AMP: mixed-precision training
+
+## Optimization
+opt: adamw     # Optimization method
+smoothing: 0.1 # Label smoothing rate
+
+## Epochs
+epochs: 300
+cooldown_epochs: 10
+warmup_epochs: 10
+warmup_lr: 0.00001
+
+## Schedule
+lr: 5e-4
+min_lr: 1e-6
+sched: cosine
+weight_decay: 5e-2


### PR DESCRIPTION
This will now work for any generic torchvision datasets. Just need to
make dataset flag in the format of 'tv-' to indicate that we want to do
this. Also allows downloading of the dataset.

-----------------------------------------------------------------------------

I went with the indicator of `tv-" as a signal that we want to use a torchvision dataset. It requires that the dataset has the correct capitalization format from torchvision itself. Note that tv can be capitalized and that the deliminator character is not strict. I can add something to the README to denote that we now have this feature or we can leave hidden for now since we aren't providing configs. Obviously others will have to calculate the correct mean and standard deviation for their datasets. 